### PR TITLE
V0.4.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.4.0] - 2024-12-06
+- Updates to survey language
+- Report bug fix
+### Added
+- Updated helper text for the ```Will your proposal contain non-residential floor area?``` question in the survey.
+  - Text went from:
+
+    ```Non-residential floor area includes commercial, community facility, interior/structured parking, manufacturing, or other floor area that is not for mechanical/utility equipment or residential floor area.```
+
+    To:
+
+    ```Non-residential floor area includes commercial, community facility, manufacturing, or other floor area that is not for mechanical/utility equipment. Include structured parking as non-residential floor area when accessory to non-residential uses.```
+  - (Addresses [#32](https://github.com/NYCPlanning/fast-tracker-tool/issues/32)) 
+### Fixed
+- Report header version number bug (Addresses [#29](https://github.com/NYCPlanning/fast-tracker-tool/issues/29))
+  - 
+### Changed
+
+### Removed
+
 ## [v0.3.0] - 2024-08-07
 - Updates to underlying web service architecture
 - Various user experience and performance improvements, and bug fixes

--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,6 @@ All notable changes to this project will be documented in this file.
   - (Addresses [#32](https://github.com/NYCPlanning/fast-tracker-tool/issues/32)) 
 ### Fixed
 - Report header version number bug (Addresses [#29](https://github.com/NYCPlanning/fast-tracker-tool/issues/29))
-  - 
 ### Changed
 
 ### Removed

--- a/changelog.md
+++ b/changelog.md
@@ -3,9 +3,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v0.4.0] - 2024-12-06
+## [v0.4.0] - 2024-12-04
 - Updates to survey language
-- Report bug fix
+- Report header data version bug fix
 ### Added
 - Updated helper text for the ```Will your proposal contain non-residential floor area?``` question in the survey.
   - Text went from:
@@ -18,6 +18,9 @@ All notable changes to this project will be documented in this file.
   - (Addresses [#32](https://github.com/NYCPlanning/fast-tracker-tool/issues/32)) 
 ### Fixed
 - Report header version number bug (Addresses [#29](https://github.com/NYCPlanning/fast-tracker-tool/issues/29))
+  - Cell in survey sheet that references the data versions table was referencing an outdated service URL.
+    - old URL: https://services5.arcgis.com/GfwWNkhOj9bNBqoJ/arcgis/rest/services/GFT_Source_Data_Versions/FeatureServer/54
+    - updated URL: https://services5.arcgis.com/GfwWNkhOj9bNBqoJ/arcgis/rest/services/v_GFT_Source_Data_Versions/FeatureServer/0
 ### Changed
 
 ### Removed


### PR DESCRIPTION
Updates to survey language and data version number bug in report header. Closes #32 and closes #29.

Bumps version from 0.3.0 to 0.4.0.