### PR TITLE
v1.1.0: handle R11/R12; other QOL changes

### DIFF
--- a/arcade/zoning-symbology.js
+++ b/arcade/zoning-symbology.js
@@ -1,41 +1,142 @@
-var zoning_array = Split($feature.ZONEDIST, "");
-var digits_array = Split("1234567890", ""); // To test if a character is a digit
-var first_char = zoning_array[0];
-var second_char = zoning_array[1];
-var zoning_category; // Initialize as null, assign later
-
-Console(`Zoning as array: ${zoning_array}`);
-Console(`Zoning array length: ${Count(zoning_array)}`);
-
-// Assign third character to variable, if it exists
-if (Count(zoning_array) < 3) {
-  var third_char;
-} else {
-  var third_char = zoning_array[2];
+function isCommercialOnly(zd_array) {
+  return zd_array[0] == "C";
 }
 
-Console(`First character (index 0): ${first_char}`);
-Console(`Second character (index 1): ${second_char}`);
-Console(`Third character (index 2): ${third_char}`);
+function isMixedUse(zd_array) {
+  return zd_array[0] == "M" && Includes(zd_array, "/");
+}
 
-if (first_char == "C" || first_char == "M") {
-  zoning_category = "C or M (including MX)";
-} else if (first_char == "R") {
-  // Test if 3rd character is a digit by comparing to the digits array.
-  // R10 and greater = High Density
-  if (Includes(digits_array, third_char)) {
-    zoning_category = "R5 - R10";
-    // R1 - R4 = Low Density
-  } else if (second_char >= "1" && second_char <= "4") {
-    zoning_category = "R1 - R4";
-    // R5 - R9 = High Density
-  } else if (second_char >= "5" && second_char <= "9") {
-    zoning_category = "R5 - R10";
+function isManufacturingOnly(zd_array) {
+  return zd_array[0] == "M" && !isMixedUse(zd_array);
+}
+
+function isResidence(zd_array) {
+  return zd_array[0] == "R";
+}
+
+function containsResidence(zd_array) {
+  return Includes(zd_array, "R");
+}
+
+function isDigit(character) {
+  var isDigit = Find(character, "0123456789") != -1;
+  return isDigit;
+}
+
+function getResidenceBase(zd_array) {
+  // ------------------------------------------
+  // Extracts the base from a residence zoning district, or -1 when
+  // no residence zoning is present. For example:
+  //  M1-1/R6A returns 6
+  //  R5 returns 5
+  //  Park returns -1
+  //  C8-4 returns -1
+  // Arg:
+  //  zd_array (array) --> NYC zoning district as array
+  // Return:
+  //  residence base zoning (number)
+  //   OR
+  //  -1 (when no residence zoning is present)
+  // ------------------------------------------
+  
+  // Get the index of "R" within the zoning array
+  var r_idx = IndexOf(zd_array, "R");
+  // Return -1 if no "R" is present (note this doesn't exclude "Park")
+  if (r_idx == -1) {
+    return -1;
   }
-} else {
-  // Everything else = Other
-  zoning_category = "Ineligible";
+  // Get arrays of all characters, both w/ and w/out the "R" prefix
+  var all_chars = Slice(zd_array, r_idx);
+  var after_r = Slice(all_chars, 1);
+
+  // Accumulate all consecutive numeric characters, after "R" prefix
+  var digits = "";
+  for (var i = 0; i < Count(after_r); i++) {
+    var char = after_r[i];
+    if (isDigit(char)) {
+      digits += char;
+    } else {
+      break; // Stop at first non-digit
+    }
+  }
+  // Return characters as number
+  if (digits != "") {
+    return Number(digits);
+  }
+  return -1;
 }
 
-Console(`Category: ${zoning_category}`);
-return zoning_category;
+function getZoningCategory(zoning_district) {
+  // ------------------------------------------
+  // Takes an NYC Zoning District and returns the Green Fast Track zoning category.
+  // Arg:
+  //  zoning_district (string) --> NYC zoning district (e.g. R4, M1-2/R11, Park)
+  // Return:
+  //  zoning category (string), which is one of:
+  //    R1 - R4
+  //    R5 - R10
+  //    C or M (including MX)
+  //    Other
+  // ------------------------------------------
+  var zoning_array = Split(zoning_district, "");
+
+  // Commercial or Manufacturing only
+  if (isCommercialOnly(zoning_array) || isManufacturingOnly(zoning_array)) {
+    return "C or M (including MX)";
+  }
+
+  // Mixed use
+  if (isMixedUse(zoning_array)) {
+    if (
+      containsResidence(zoning_array) && getResidenceBase(zoning_array) >= 11
+    ) {
+      return "Other";
+    }
+    return "C or M (including MX)";
+  }
+
+  // Residential
+  if (isResidence(zoning_array)) {
+    var res_base = getResidenceBase(zoning_array);
+    if (res_base <= 4) {
+      return "R1 - R4";
+    } else if (res_base < 11) {
+      return "R5 - R10";
+    } else if (res_base > 11) {
+      return "Other";
+    }
+  }
+
+  // Everything else
+  return "Other";
+}
+
+// For production ---
+var zone_dist = $feature.ZONEDIST;
+Console(zone_dist);
+getZoningCategory(zone_dist);
+// ------------------
+
+// For testing ------
+// var districts = [
+//   "R11",
+//   "C8-4",
+//   "R4",
+//   "M1-2/R11",
+//   "Park",
+//   "R12",
+//   "R1-2",
+//   "M1-2/R5",
+//   "MX-11",
+//   "R3B",
+//   "R10A",
+//   "R12D",
+//   "R3-B",
+//   "R3*Z"
+// ];
+// for (var zd in districts) {
+//   Console(
+//     `ZD: ${districts[zd]}, Category: ${getZoningCategory(districts[zd])}`
+//   );
+// }
+// ------------------

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,24 @@
 # Changelog
 ## Fast Tracker Application
 
-All notable changes to this project will be documented in this file.
+All notable changes to the app, survey, and report aspects of this project will be documented in this file. Back end data engineering changes are tracked in a different [repository](https://github.com/NYCPlanning/data-engineering/), and may sometimes be referenced directly in this changelog.
+
+## [v1.1.0] - 2026-01-20
+Updates to handle new residence zoning districts, plus quality of life enhancements. 
+
+Accompanied by code changes in the NYC Planning Data Engineering repo to handle new R11 and R12 zoning districts. See data-engineering issue [#2032](https://github.com/NYCPlanning/data-engineering/issues/2032)
+
+### Added
+- Caveat text to front page of app, to better clarify that the app results are provisional and subject to additional review by applicant and lead agency (Addresses [#37](https://github.com/NYCPlanning/fast-tracker-tool/issues/37))
+- Survey and report question to handle new R11 or R12 residence districts as "Other". (Addresses [#52](https://github.com/NYCPlanning/fast-tracker-tool/issues/52) and partially [#51](https://github.com/NYCPlanning/fast-tracker-tool/issues/51))
+
+### Fixed
+### Changed
+- Map symbology logic to handle new R11 or R12 residence districts as "Other". (Addresses [#51](https://github.com/NYCPlanning/fast-tracker-tool/issues/51))
+- Underlying data pipeline code to process new R11 or R12 residence districts as "Other". (Addresses [#2032](https://github.com/NYCPlanning/data-engineering/issues/2032))
+- "Submit" button text at bottom of survey to read "Generate". (Addresses [#37](https://github.com/NYCPlanning/fast-tracker-tool/issues/37)) 
+
+
 ## [v1.0.1] - 2025-08-25
 Quality of life enhancements, derived from user feedback.
 

--- a/zoning_symbology.csv
+++ b/zoning_symbology.csv
@@ -1,0 +1,5 @@
+﻿category,symbol type,fill color,fill transparency,outline color,outline transparency,outline width,pattern,patter color,pattern transparency,pattern width,pattern rotation,pattern separation,pattern offset
+R1 - R4,Basic polygon,ffffbe,30,null,null,null,null,null,null,null,null,null,null
+R5 - R10,Basic polygon,ffd37f,31,null,null,null,null,null,null,null,null,null,null
+C or M (including MX),Basic polygon,f47ba8,32,null,null,null,null,null,null,null,null,null,null
+Other (Ineligible),Vector polygon,null,null,null,null,null,hatch fill,ad4200,20,2,45,5,0


### PR DESCRIPTION
### Summary
New R11 and R12 zoning districts have been introduced in NYC that are not eligible for the Green Fast Track for housing. This PR covers changes to handle the new ZDs via changes to symbology code, survey text, report text. Also includes quality of life changes to the submit button and front-page disclaimer text. More details can be viewed in the changelog file.

### Focus
While this PR relates to some non-git-tracked work (survey, report, web map changes), the relevant changes to focus on here are the updates to the Arcade symbology code, and the changelog text.

### Success/completion criteria
- DE code completed
- Arcade/symbology code completed and vetted
- Survey updates completed
- Report updates completed
- App interface/text changes completed
- Changelog updated

### Issues
Impacts milesone: [Release v1.1.0](https://github.com/NYCPlanning/fast-tracker-tool/milestone/6)
Closes #37 
Closes #43 
Closes #51 
Closes #52 
Closes #53 
Closes #54 

### Review notes
2025-12-16 :: Draft PR:
* @UshashiP + @caseysmithpgh this PR is in draft, and is ready for preliminary review
* Focus on the arcade code. Note that the snippet has some commented out testing code at the bottom to make this easier to run on the [Arcade Playground](https://developers.arcgis.com/arcade/playground/) site.
* I've also run some visual tests in Pro, by using the Arcade to symbolize nyzd, and checking for inconsistencies between label and symbology
* Try to break it! There are definitely testing avenues I haven't explored
* Check out the changelog. This is also subject to some change if CAPS has significant feedback, but should already capture most of the changes included in the scope of this PR
